### PR TITLE
コンテナ上で開発環境を立ち上げるようにする

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "poep",
+  "dockerFile": "../Dockerfile",
+  "build": {
+    "target": "development"
+  },
+  "forwardPorts": [
+    4000
+  ],
+  "extensions": [
+    "svelte.svelte-vscode"
+  ]
+}

--- a/DockerFile
+++ b/DockerFile
@@ -1,12 +1,67 @@
-FROM node:lts
+# 開発環境用のイメージビルド
+
+## Ubuntuをベースイメージとして、開発環境を作成
+FROM ubuntu:22.04 AS development
+
+## ワーキングディレクトリの設定
 WORKDIR /app
-COPY package.json ./
-COPY svelte.config.js ./
-COPY tsconfig.json ./
-COPY vite.config.ts ./
+
+## 必要なパッケージのインストール
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_21.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get install -y git
+
+## 以前の依存関係のクリーンアップ
+RUN rm -rf /app/node_modules /app/package-lock.json
+
+## アプリケーションの依存関係をインストール
+COPY package.json /app/
 RUN npm install
-COPY . .
-RUN npm run build
+
+## その他のプロジェクトファイルをコピー
+COPY . /app
+
+## ポート4000を公開
 EXPOSE 4000
-CMD ["npm", "run", "preview"]
-# CMD ["npm", "run", "dev"]
+
+# remoteから操作するユーザ設定
+RUN adduser --disabled-password --gecos '' vscode
+RUN chown -R vscode:vscode /app
+USER vscode
+
+## コンテナ起動時にnpmアプリを起動
+CMD npm run dev
+
+
+# 本番環境用のイメージビルド
+
+## Ubuntuをベースイメージとして、本番環境を作成
+FROM ubuntu:22.04 AS production
+
+## ワーキングディレクトリの設定
+WORKDIR /app
+
+## 必要なパッケージのインストール
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_21.x | bash - && \
+    apt-get install -y nodejs
+
+## 以前の依存関係のクリーンアップ
+RUN rm -rf /app/node_modules /app/package-lock.json
+
+## アプリケーションの依存関係をインストール
+COPY package.json /app/
+RUN npm install --only=production
+
+## その他のプロジェクトファイルをコピー
+COPY . /app
+
+## ポート3000を公開
+EXPOSE 3000
+
+## コンテナ起動時にnpmアプリを起動
+RUN npm run build
+CMD node start

--- a/README.md
+++ b/README.md
@@ -1,38 +1,21 @@
-# create-svelte
+# poepについて
+（記述してください）
 
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/main/packages/create-svelte).
+## Dockerfileの実行について
 
-## Creating a project
+Dockerfileのイメージ作成は開発環境と本番環境で異なります。<br>
+[Dockerfileのマルチステージビルド](https://docs.docker.jp/engine/userguide/eng-image/multistage-build.html#id4)を使用して環境ごとにコンテナ作成を分岐しています。
 
-If you're seeing this, you've probably already done this step. Congrats!
+### 開発環境のコマンド
+Visual Studio Codeの[Dev Containerプラグイン](https://code.visualstudio.com/docs/devcontainers/containers)を使用して、コンテナ上に立ち上げた開発環境をローカルのローカルのVisual Studio Codeで開発します。<br>
 
-```bash
-# create a new project in the current directory
-npm create svelte@latest
+-  環境構築手順
 
-# create a new project in my-app
-npm create svelte@latest my-app
-```
+1. Visual Studio Codeの拡張機能からDev Containersをインストールします。
+2. インストール完了後、Visual Studio Codeのコマンドパレット(Command+Shift+p)から、Reopen in Containerを実行します。これで開発環境用のコンテナが起動し、Visual Studio Codeから操作可能になります。
+3. (work arround)起動後、Visual Studio Code内でターミナルを開き、npm run devを実行します。<br>
 
-## Developing
+以上で開発環境の構築は完了です。
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
-
-```bash
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
-```
-
-## Building
-
-To create a production version of your app:
-
-```bash
-npm run build
-```
-
-You can preview the production build with `npm run preview`.
-
-> To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+### 本番環境のコマンド
+（記述してください）

--- a/makefile
+++ b/makefile
@@ -1,27 +1,13 @@
-# Makefile
+# makeで実行されるデフォルト
+default: build run
 
-# イメージ名を定義
-IMAGE_NAME=poep_sox
-
-# タグ名を定義
-MY_TAG=demo
-
-# ポート番号を定義
-HOST_PORT=4000
-DOCKER_PORT=4000
-
-# Dockerイメージをビルドするためのターゲット
+# dockerイメージを作成
 build:
-	docker build -t $(IMAGE_NAME):$(MY_TAG) .
+	docker build --target development -t poep:dev .
 
-# コンテナを起動するためのターゲット
+# dockerコンテナを作成
 run:
-	docker run -d -p $(HOST_PORT):$(DOCKER_PORT) $(IMAGE_NAME):$(MY_TAG)
+	docker run -dp 4000:3000 poep:dev
 
-# コンテナをkillするためのターゲット
-kill:
-	@docker ps -q | xargs -r docker kill
-
-
-# イメージのビルドとコンテナの起動を行うターゲット
-all: build run
+# Phony targets
+.PHONY: default build run

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
 	"name": "sveltekit-first",
 	"version": "0.0.1",
 	"scripts": {
-		"dev": "vite dev",
+		"dev": "vite dev --port 3000",
 		"build": "vite build",
-		"preview": "vite preview",
+		"preview": "vite preview --port 4000",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,13 +4,6 @@ import { defineConfig } from 'vite';
 export default defineConfig({
 	plugins: [sveltekit()],
 	server: {
-		host: true,
-		port: 3000, // ここに希望のポート番号を設定
-		watch: {
-			usePolling: true,
-		  },
-	},
-	preview: {
-        port: 4000
-    }
+		host: true
+	}
 });


### PR DESCRIPTION
開発環境を統一するため、Docker コンテナ上で開発できるように整備しました。
詳細はREADMEを読んでください。

Dev Contaiersでdockerコンテナを作成するとCMDコマンドが走らない（失敗する）バグが発生しています。
原因特定できていないので、暫定対応で進めています。
観光構築手順が1工程増えていますが、動作には問題ないので今断面でPUSHします。